### PR TITLE
Add AMS1117

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ These are ones I've found that are JLCPCB compatible.
 |[M3406-ADJ](https://datasheet.lcsc.com/lcsc/1811151539_XI-AN-Aerosemi-Tech-M3406-ADJ_C83224.pdf)|[C83224](https://www.lcsc.com/product-detail/DC-DC-Converters_XI-AN-Aerosemi-Tech-M3406-ADJ_C83224.html)|SOT-23-5|Step-down type SOT-23-5, 2-6.5 in, 800mA Out|0.025|
 |[RS3236-3-3YUTDN4](https://datasheet.lcsc.com/lcsc/2202251530_Jiangsu-RUNIC-Tech-RS3236-3-3YUTDN4_C379350.pdf)|[C379350](https://www.lcsc.com/product-detail/Linear-Voltage-Regulators-LDO_Jiangsu-RUNIC-Tech-RS3236-3-3YUTDN4_C379350.html)|X-DFN-4|3.3V 500mA LDO|0.0542|
 |[XT1861B362MR-G]()|[C236397](https://www.lcsc.com/product-detail/DC-DC-Converters_NATLINEAR-XT1861B362MR-G_C236397.html)|SOT-23|3.6V Boost LXmax 800mA|0.0511|
-
+|[AMS1117-3.3](https://datasheet.lcsc.com/lcsc/2304140030_Advanced-Monolithic-Systems-AMS1117-3-3_C6186.pdf)|SOT-223|awesome cheap and reliable 3.3V fixed output linear regulator with up to 1A driving capabiility, there is also a 5V variant, both are basic parts at JLCPCB|0.1382|
 
 ## Totally random things
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ These are ones I've found that are JLCPCB compatible.
 |[M3406-ADJ](https://datasheet.lcsc.com/lcsc/1811151539_XI-AN-Aerosemi-Tech-M3406-ADJ_C83224.pdf)|[C83224](https://www.lcsc.com/product-detail/DC-DC-Converters_XI-AN-Aerosemi-Tech-M3406-ADJ_C83224.html)|SOT-23-5|Step-down type SOT-23-5, 2-6.5 in, 800mA Out|0.025|
 |[RS3236-3-3YUTDN4](https://datasheet.lcsc.com/lcsc/2202251530_Jiangsu-RUNIC-Tech-RS3236-3-3YUTDN4_C379350.pdf)|[C379350](https://www.lcsc.com/product-detail/Linear-Voltage-Regulators-LDO_Jiangsu-RUNIC-Tech-RS3236-3-3YUTDN4_C379350.html)|X-DFN-4|3.3V 500mA LDO|0.0542|
 |[XT1861B362MR-G]()|[C236397](https://www.lcsc.com/product-detail/DC-DC-Converters_NATLINEAR-XT1861B362MR-G_C236397.html)|SOT-23|3.6V Boost LXmax 800mA|0.0511|
-|[AMS1117-3.3](https://datasheet.lcsc.com/lcsc/2304140030_Advanced-Monolithic-Systems-AMS1117-3-3_C6186.pdf)|SOT-223|awesome cheap and reliable 3.3V fixed output linear regulator with up to 1A driving capabiility, there is also a 5V variant, both are basic parts at JLCPCB|0.1382|
+|[AMS1117-3.3](https://datasheet.lcsc.com/lcsc/2304140030_Advanced-Monolithic-Systems-AMS1117-3-3_C6186.pdf)|[C6186](https://www.lcsc.com/product-detail/Linear-Voltage-Regulators-LDO_Advanced-Monolithic-Systems-AMS1117-3-3_C6186.html)|SOT-223|awesome cheap and reliable 3.3V fixed output linear regulator with up to 1A driving capability, there is also a 5V variant, both are basic parts at JLCPCB|0.1382|
 
 ## Totally random things
 


### PR DESCRIPTION
Hi, thanks for the awesome repo.

I felt adding the AMS1117 to the power supplies list is appropriate.
It is imho the best linear regulator out there for the price, made in absolute masses for ages now. And it is cheap, super reliable and
the package allows for proper cooling because of the large tab. And at JLCPCB both 3.3V and 5V variants are basic parts, so using it is essentially free. (as non-basic there exists also the ADJ-variant which can vary output by resistor divider).
Best is the 1A output capability and all you need is basically 1 22u cap each at input and output, also available as basic parts at JLC.

It is my go-to powersupply for small boards where I want to step down 5V USB power to 3.3V for the other ICs, it is super common e.g. on ESP32 boards.

Highly recommend it.